### PR TITLE
Eblocal names

### DIFF
--- a/fuzzup/whitelists.py
+++ b/fuzzup/whitelists.py
@@ -1,4 +1,3 @@
-from tracemalloc import get_traceback_limit
 from typing import List, Dict, Callable
 import logging
 

--- a/fuzzup/whitelists.py
+++ b/fuzzup/whitelists.py
@@ -1,3 +1,4 @@
+from tracemalloc import get_traceback_limit
 from typing import List, Dict, Callable
 import logging
 
@@ -154,6 +155,14 @@ def get_municipalities():
     data = requests.get(url).json() 
     whitelist = {" ".join([x.get('navn'), "Kommune"]): {'municipality_code': x.get('kode')} for x in data}
     return whitelist
+
+def get_eblocal_names():
+    url = 'https://misty-beirut-ryz6j4qt64tt.vapor-farm-b1.com/api/eblocals'
+    eblocals = requests.get(url).json()
+    # remove "hits"
+    eblocals.pop(0)
+    out = {x['eblocal_name'] : {'eblocal_id': x['eblocal_id']} for x in eblocals}
+    return out
 
 def get_neighborhoods():
     """Get all neighborhoods in DK"""
@@ -393,6 +402,21 @@ class Municipalities(Whitelist):
                          entity_group=['LOC'],
                          **kwargs)
         
+class EBLocalNames(Whitelist):
+    """EB Local Names
+    
+    Whitelist with Ekstra Bladet Local Names.
+    """
+    
+    def __init__(self,
+                 **kwargs):
+        
+        super().__init__(function_load=get_eblocal_names,
+                         title='eblocal_name',
+                         entity_group=['LOC'],
+                         **kwargs)
+
+        
 class Neighborhoods(Whitelist):
     """Danish Neighborhoods
     
@@ -429,3 +453,4 @@ class Politicians(Whitelist):
                          entity_group=['PER'],
                          **kwargs
                          )
+

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="fuzzup", 
-    version="0.3.6",
+    version="0.3.7",
     author="Lars Kjeldgaard",
     author_email="lars.kjeldgaard@eb.dk",
     description="A Fuzzy Matching Approach for Clustering Strings",

--- a/tests/test_whitelists.py
+++ b/tests/test_whitelists.py
@@ -6,7 +6,8 @@ from fuzzup.whitelists import (
     Municipalities,
     Neighborhoods,
     format_output,
-    apply_whitelists
+    apply_whitelists,
+    EBLocalNames
 )
 from fuzzup.fuzz import fuzzy_cluster
 
@@ -96,4 +97,6 @@ def test_format_no_match_on_subcategory():
     assert isinstance(out, pd.DataFrame)
     assert len(out) > 0
 
-  
+def test_EBLocalNames():
+    EBLocalNames()
+      


### PR DESCRIPTION
har tilføjet ny whitelist, der indeholder unikke EBLOCAL_NAMES, måske det kan bruges til en start.

Skal anvendes sammen med `Municipalities` whitelist.